### PR TITLE
Handle authentication prior to each request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ yarn-error.log*
 .env.test.local
 .env.production.local
 node_modules
+
+# sqlite db
+*.db

--- a/main.js
+++ b/main.js
@@ -1,13 +1,22 @@
 const express = require("express");
 const next = require("next");
+const Keyv = require('keyv');
 //const port = 8080;
-const port = process.env.PORT || 8080;
+const port = process.env.PORT || 8081;
 const { Client } = require("pg");
-
+const keyv = new Keyv("sqlite://auth.db");
 const dev = process.env.NODE_ENV !== "production";
 const app = next({ dev });
 const handle = app.getRequestHandler();
 const db = require("./models");
+const bodyParser = require('body-parser')
+const cookieParser = require('cookie-parser');
+const lti = require("ims-lti");
+
+const jsonParser = bodyParser.json();
+const consumer_key = "my_consumer_key"
+const consumer_secret = "this_is_a_bad_secret123"
+const AUTH_HOURS = 16;
 
 // // LTI server stuff
 // const lti = require("ltijs").Provider;
@@ -19,17 +28,73 @@ app
   .then(() => {
     // EXPRESS SERVER
     const server = express();
+    server.use(bodyParser.urlencoded({ extended: false }))
+    server.use(bodyParser.json());
+    server.use(cookieParser());
+    
     //connecting to database, connect function defined in /models/index.js
     (async () => {
       await db.connect();
     })();
 
-    server.get("*", (req, res) => {
+    server.post("*", async function(req, res, next) {
+
+      //If the user is authenticated, immediately handle the request
+      var userData = {};
+      if (req.cookies && req.cookies.authToken){
+        var nonce = req.cookies.authToken;
+        userData = await keyv.get(nonce);
+        console.log(userData)
+        if (userData){
+          req.userData = userData;
+          return handle(req, res);
+        }
+      } 
+      
+      //Otherwise, check if the request has valid LTI credentials and authenticate the user if that's the case
+      var provider = new lti.Provider(consumer_key, consumer_secret)
+      provider.valid_request(req, (err, is_valid) => {
+        if (is_valid) {
+          
+          //copying all the useful data from the provider to what will be stored for the user
+          userData.user_id = provider.body.user_id;
+          userData.context_id = provider.context_id;
+          userData.instructor = provider.instructor;
+          userData.ta = provider.ta;
+          userData.student = provider.student;
+          userData.admin = provider.admin;
+          userData.assignment = provider.body.ext_lti_assignment_id;
+
+          //The nonce is used as the auth token to identify the user to their data
+          var nonce = Object.keys(provider.nonceStore.used)[0];
+          res.cookie('authToken', nonce, AUTH_HOURS * 1000 * 60 * 60);
+          keyv.set(nonce, userData, AUTH_HOURS * 1000 * 60 * 60);
+          req.userData = userData;
+        }
+      });
+      //only add the userData if it was modified. That way, future handlers just have to check if userData exists to check authentication status
+      if (Object.keys(userData).length > 0) {
+        req.userData = userData;
+      }
+      console.log("DOING NEXT");
       return handle(req, res);
+      
+      
     });
-    server.post("*", (req, res) => {
+    server.get("*", async (req, res) => {
+      var userData = {};
+      if (req.cookies && req.cookies.authToken){
+        var nonce = req.cookies.authToken;
+        userData = await keyv.get(nonce);
+        if (userData){
+          req.userData = userData;
+        } 
+      } 
+      var data  = await req.userData;
       return handle(req, res);
+
     });
+   
     server.listen(port, (err) => {
       if (err) throw err;
       console.log(`> App running on ${port}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2684,6 +2684,40 @@
       "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-2.0.0.tgz",
       "integrity": "sha512-OWm/xa9O9e4ugzNHoRT3IsXZZYfaV6Ia1aRwctOmCQ2GYWMnhKBzMC1WomqCh/oGxEZKNtPy5xv5//VIAOgMqw=="
     },
+    "@keyv/sql": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@keyv/sql/-/sql-1.1.2.tgz",
+      "integrity": "sha1-HdhKXFrSOE34k08N3+IKuB3Cp10=",
+      "requires": {
+        "sql": "~0.78.0"
+      }
+    },
+    "@keyv/sqlite": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@keyv/sqlite/-/sqlite-2.0.2.tgz",
+      "integrity": "sha512-vVaAOK/oCNCzNyB8AjiozAuJ0MqXt9uLsJ0oyQIEEdVw61HHOFiyjdYOGVkxHkgXDoJGF7g6T5ekh5JpdYFz5w==",
+      "requires": {
+        "@keyv/sql": "1.1.2",
+        "pify": "3.0.0",
+        "sqlite3": "^4.1.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "sqlite3": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.2.0.tgz",
+          "integrity": "sha512-roEOz41hxui2Q7uYnWsjMOTry6TcNUNmp8audCx18gF10P2NknwdpF+E+HKvz/F2NvPKGGBF4NGc+ZPQ+AABwg==",
+          "requires": {
+            "nan": "^2.12.1",
+            "node-pre-gyp": "^0.11.0"
+          }
+        }
+      }
+    },
     "@material-ui/core": {
       "version": "4.11.0",
       "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.0.tgz",
@@ -10502,9 +10536,9 @@
       "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
     },
     "keyv": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.1.tgz",
-      "integrity": "sha512-xz6Jv6oNkbhrFCvCP7HQa8AaII8y8LRpoSm661NOKLr4uHuBwhX4epXrPQgF3+xdJnN4Esm5X0xwY4bOlALOtw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
       "requires": {
         "json-buffer": "3.0.1"
       }
@@ -11249,8 +11283,7 @@
     "nan": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "optional": true
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -14363,6 +14396,27 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
+    "sql": {
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/sql/-/sql-0.78.0.tgz",
+      "integrity": "sha1-iUWF1WER27F2h0Gk2ZNcgshZWUk=",
+      "requires": {
+        "lodash": "4.1.x",
+        "sliced": "0.0.x"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.1.0.tgz",
+          "integrity": "sha1-KZiUKD3gGp7vvt/0xLmwCmoubpY="
+        },
+        "sliced": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
+          "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
+        }
+      }
     },
     "sqlite3": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -9,24 +9,27 @@
     "node": "12.18.3"
   },
   "scripts": {
-    "dev": "NODE_ENV=development node ./main.js",
+    "dev": "set NODE_ENV=development && node ./main.js",
     "build": "next build",
     "start": "NODE_ENV=production node main.js -p $PORT",
     "deploy-production": "NODE_ENV=production next build && NODE_ENV=production node ./main.js",
     "test": "cross-env NODE_ENV=test jest --testTimeout=10000 --detectOpenHandles"
   },
   "dependencies": {
+    "@keyv/sqlite": "^2.0.2",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "axios": "^0.19.2",
     "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.5",
     "express": "^4.17.1",
     "formik": "^2.1.5",
     "fs": "0.0.1-security",
     "grommet": "^2.14.0",
     "grommet-icons": "^4.4.0",
     "ims-lti": "^3.0.2",
+    "keyv": "^4.0.3",
     "ltijs": "^5.0.3",
     "ltijs-sequelize": "^1.0.6",
     "net": "^1.0.2",


### PR DESCRIPTION
This commit moves LTI authentication as a "hacky" middleware that occurs before each request. As it currently stands, the field ```userData``` will be added to ```req``` if the user is authenticated.

The ```userData``` is a truncated version of the provider data, and should be all that we need to render each page. The data is stored in a SQLite database (basically just a file). The decision for this is that Heroku servers have limited memory capacity, so it made sense to use an on disk database, and SQLite requires no extra installation other than the npm package.

The expiration time of user authentication can be set by changing the ```AUTH_HOURS``` parameter in main.js. Currently set to 16, the user will not have to reauthenticate until those 16 hours have passed.