### PR TITLE
Format user-facing dates and times to match canvas style

### DIFF
--- a/components/assignmentchecklist.js
+++ b/components/assignmentchecklist.js
@@ -7,6 +7,7 @@ import Step from "@material-ui/core/Step";
 import StepLabel from "@material-ui/core/StepLabel";
 import Switch from '@material-ui/core/Switch';
 import axios from 'axios';
+import {formatTimestampLikeCanvas, formatTimestampWithWeekday} from "./dateUtils";
 
 
 const useStyles = makeStyles((theme) => ({
@@ -26,11 +27,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 
-function formatTimestamp(timestamp) {
-  var d = new Date(timestamp);
-  return ((d.getMonth() + 1) + '/' + d.getDate() + '/' + d.getFullYear());
 
-}
 function getSteps() {
   return [
     ["Initialize: ", { 'link': '/assignments/initialchecklist/initialchecklist' }],
@@ -137,7 +134,7 @@ function assignmentchecklist(props) {
                   {/* TO DO : CHANGE INLINE STYLING */}
                   <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
                     <div style={{ marginRight: '10px' }}>{label[0]}</div>
-                    {formatTimestamp(label[0] == "Assignment Due Date: " ? dueDate : prDueDate)}
+                    {formatTimestampWithWeekday(label[0] === "Assignment Due Date: " ? dueDate : prDueDate)}
                   </div>
                 </StepLabel>
 

--- a/components/dateUtils.js
+++ b/components/dateUtils.js
@@ -1,0 +1,20 @@
+
+function formatTimestampLikeCanvas(timestamp) {
+    if (!timestamp) return ""
+    var d = new Date(timestamp);
+    return d.toLocaleString('en-US', {month: 'short', day: 'numeric',
+            year: d.getFullYear() === new Date().getFullYear() ? undefined : 'numeric'})
+        + " at " +
+        d.toLocaleString('en-US', {hour: 'numeric', minute: 'numeric'})
+            .replace(":00", "")
+            .replace(" AM", "am")
+            .replace(" PM", "pm");
+}
+
+function formatTimestampWithWeekday(timestamp) {
+    if (!timestamp) return "";
+    var d = new Date(timestamp);
+    return d.toLocaleString('en-US', {weekday: 'short'}) + " " + formatTimestampLikeCanvas(timestamp)
+}
+
+export { formatTimestampLikeCanvas, formatTimestampWithWeekday }

--- a/components/listcontainer.js
+++ b/components/listcontainer.js
@@ -6,13 +6,14 @@ import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Link from 'next/link'
+import {formatTimestampLikeCanvas} from "./dateUtils";
 
 function Info(props) { // Display list item description
   const dueDate = props.dueDate;
   const info = props.info;
   if (dueDate) {
-    let newDate = new Date(dueDate);
-    let dateText = props.type + " Due: " + (newDate.getMonth()+1)+'-' + newDate.getDate()+'-' + newDate.getFullYear();
+    // let newDate = new Date(dueDate);
+    let dateText = props.type + " Due " + formatTimestampLikeCanvas(dueDate);
     return <TableCell className={styles.info} > {dateText} </TableCell>
   }
   else {

--- a/pages/assignments/appeals/appeals.js
+++ b/pages/assignments/appeals/appeals.js
@@ -13,6 +13,7 @@ import StudentViewOutline from '../../../components/studentViewOutline';
 import ReloadMatchings from "../../../components/reloadMatchings";
 const axios = require("axios");
 import SubmitButton from '../../../components/submitButton';
+import {formatTimestampLikeCanvas} from "../../../components/dateUtils";
 
 
 function Appeals(props) {
@@ -27,11 +28,6 @@ function Appeals(props) {
   const [peerReviews, setPeerReviews] = useState([]);
   const [submitSuccess, setSubmitSuccess] = useState(true)
 
-  function formatTimestamp(timestamp) {
-    var d = new Date(timestamp);
-    return ((d.getMonth() + 1) + '/' + d.getDate() + '/' + d.getFullYear());
-
-  }
   useEffect(() => {
     Promise.all([
       axios.get(`/api/assignments/${assignmentId}`),
@@ -41,7 +37,7 @@ function Appeals(props) {
       let peerReviewData = data[1].data.data
       setPeerReviews(peerReviewData);
       if (assignmentData.appealsDueDate) {
-        let formattedDate = formatTimestamp(assignmentData.appealsDueDate);
+        let formattedDate = formatTimestampLikeCanvas(assignmentData.appealsDueDate);
         setLoadedDeadline(formattedDate);
         setExistingDueDate(true);
         console.log('got date:', formattedDate)

--- a/pages/assignments/initialchecklist/initialchecklist.js
+++ b/pages/assignments/initialchecklist/initialchecklist.js
@@ -13,6 +13,7 @@ import { PanoramaFishEye } from "@material-ui/icons";
 import StudentViewOutline from '../../../components/studentViewOutline';
 const axios = require("axios");
 import SubmitButton from '../../../components/submitButton';
+import {formatTimestampLikeCanvas, formatTimestampWithWeekday} from "../../../components/dateUtils";
 
 
 const InitialChecklist = (props) => {
@@ -33,11 +34,6 @@ const InitialChecklist = (props) => {
   const [submitResponse, setSubmitResponse] = React.useState("");
   const [submitSuccess, setSubmitSuccess] = React.useState(true)
   // new info stop
-  let localDate = new Date(dueDate);
-  // const courseId = 1 // hardcoded
-  // const assignmentId = 7
-  // const assignmentName = "Peer Reviews Static"
-  // console.log({rubricOptions});
 
 
   async function uploadRubrics(rawRubrics) {
@@ -193,12 +189,12 @@ const InitialChecklist = (props) => {
               Due Dates
             </div>
             <div className={styles.column__content}>
-              Due date for the original assignment:
+              Original assignment due:
               <div>
-                <p>{(localDate.getMonth() + 1) + '/' + localDate.getDate() + '/' + localDate.getFullYear()}</p>
+                <p>{formatTimestampWithWeekday(dueDate)}</p>
               </div>
               <div style={{marginTop: '25px'}}>
-              Due date for the peer review assignment:
+              Peer review assignment due:
               <form noValidate>
                 <TextField
                   id="datetime-local"
@@ -212,6 +208,7 @@ const InitialChecklist = (props) => {
                   }}
                 />
               </form>
+              <div>{formatTimestampWithWeekday(prDueDate)}</div>
               </div>
 
             </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -170,11 +170,6 @@ function Dashboard(props) {
           .then(response => {
             const allCanvasAssignments = response.data.data;
 
-            console.log({allCanvasAssignments});
-
-            // let today = new Date();
-            // today.setHours(today.getHours() - 1); // add 1 hour offset
-
             const finishedAssignmentIds = assignments
               .filter(({reviewStatus}) => reviewStatus >= 9)
               .map(({canvasId}) => parseInt(canvasId));

--- a/pages/peer_reviews/peerreview.js
+++ b/pages/peer_reviews/peerreview.js
@@ -9,6 +9,7 @@ import Button from "@material-ui/core/Button";
 import Box from '@material-ui/core/Box';
 import { FormatColorResetTwoTone } from "@material-ui/icons";
 import ButtonExample from '../../pages/peer_reviews/prbutton'
+import {formatTimestampLikeCanvas} from "../../components/dateUtils";
 // import TAGrading from "../grading/tagrading";
 // import ReviewGradingTable from "../../components/UI/ReviewGradingTable";
 
@@ -30,10 +31,7 @@ const PeerReview = (props) => {
   const router = useRouter()
   const { submissionId, id, rubricId, matchingId, subId, dueDate } = router.query;
 
-  const currentDate = new Date();
-  const currentDateFormatted = currentDate.getFullYear() + '-' + (currentDate.getMonth()+1) + '-' + currentDate.getDate() +' '+ currentDate.getHours()+':'+ currentDate.getMinutes()+':'+ currentDate.getSeconds();
-  const reviewDueDate = new Date(dueDate);
-  const reviewDueDateFormatted = reviewDueDate.getFullYear() + '-' + (reviewDueDate.getMonth()+1) + '-' + reviewDueDate.getDate() +' '+ reviewDueDate.getHours()+':'+ reviewDueDate.getMinutes()+':'+ reviewDueDate.getSeconds();
+  const reviewDueDateFormatted = formatTimestampLikeCanvas(dueDate);
   const assignmentCompleted = isDisabled();
 
   useEffect(() => {

--- a/pages/peer_reviews/prbutton.js
+++ b/pages/peer_reviews/prbutton.js
@@ -8,6 +8,7 @@ import { useRouter } from 'next/router';
 import Button from "@material-ui/core/Button";
 import Box from '@material-ui/core/Box';
 import { FormatColorResetTwoTone } from "@material-ui/icons";
+import {formatTimestampLikeCanvas} from "../../components/dateUtils";
 
 const getData = async url => {
     const res = await fetch(url);
@@ -31,12 +32,9 @@ const getData = async url => {
   
     // let presetComments = ReviewGradingTable;
     // console.log('presetComments:',presetComments);
-  
-    // const current = new Date();
-    // const date = `${current.getDate()}/${current.getMonth()+1}/${current.getFullYear()}`;
+
   
     var currentDate = new Date();
-    var currentDateFormatted = currentDate.getFullYear() + '-' + (currentDate.getMonth()+1) + '-' + currentDate.getDate() +' '+ currentDate.getHours()+':'+ currentDate.getMinutes()+':'+ currentDate.getSeconds();
     // const newCurrentDate = "Current Date and Time: "+date;
     // console.log('currentDateFormatted:',currentDateFormatted);
     // console.log('currentDate.getTime():',currentDate.getTime());
@@ -45,7 +43,7 @@ const getData = async url => {
     // console.log('reviewDueDate:',reviewDueDate)
     // console.log('reviewDueDate.getTime():',reviewDueDate.getTime());
   
-    var reviewDueDateFormatted = reviewDueDate.getFullYear() + '-' + (reviewDueDate.getMonth()+1) + '-' + reviewDueDate.getDate() +' '+ reviewDueDate.getHours()+':'+ reviewDueDate.getMinutes()+':'+ reviewDueDate.getSeconds();
+    var reviewDueDateFormatted = formatTimestampLikeCanvas(dueDate);
   
     useEffect(() => {
       (async () => {


### PR DESCRIPTION
### Canvas formats date-times like so:
<img width="402" alt="image" src="https://github.com/nu-peerpal/Peer-Grading-Hosting/assets/63759434/ac94c0fb-203e-4ac6-b0df-2426eb820269">
<img width="427" alt="image" src="https://github.com/nu-peerpal/Peer-Grading-Hosting/assets/63759434/ce86e611-cebe-4096-b9c3-35b2d24961bb">


### This pull request formats peerpal dates and times in this same style:
<img width="431" alt="image" src="https://github.com/nu-peerpal/Peer-Grading-Hosting/assets/63759434/db614c68-2269-4fa1-a13b-4e433b93ff48">
<img width="346" alt="image" src="https://github.com/nu-peerpal/Peer-Grading-Hosting/assets/63759434/eb3fec16-03a4-4c6a-8f06-e40d2102366f">
<img width="377" alt="image" src="https://github.com/nu-peerpal/Peer-Grading-Hosting/assets/63759434/782d6742-aa3c-4b3b-8b24-ce94ba7572e1">
<img width="517" alt="image" src="https://github.com/nu-peerpal/Peer-Grading-Hosting/assets/63759434/bc5830de-4a32-4b30-8ae4-2d1b56273f0d">
